### PR TITLE
Support filtering all test cases without failing the whole test suite

### DIFF
--- a/src/BotiumBindings.js
+++ b/src/BotiumBindings.js
@@ -96,9 +96,10 @@ module.exports = class BotiumBindings {
       this.compiler.scriptingEvents.fail = failCb
     }
 
+    let testCount = 0
     this.compiler.convos.forEach((convo) => {
       debug(`adding test case ${convo.header.toString()}`)
-      testcaseCb(convo, (testcaseDone) => {
+      const included = testcaseCb(convo, (testcaseDone) => {
         if (this.container) {
           debug(`running testcase${convo.header.toString()}`)
 
@@ -115,7 +116,13 @@ module.exports = class BotiumBindings {
           testcaseDone(new Error('Botium Initialization failed. Please see error messages above (enable debug logging).'))
         }
       })
+      if (included) {
+        testCount++
+      }
     })
+    if (testCount == 0) {
+      it.skip('skip empty test suite', () => {})
+    }
   }
 
   UserSaysText (...args) {

--- a/src/helpers/jasmine.js
+++ b/src/helpers/jasmine.js
@@ -9,7 +9,7 @@ const setupJasmineTestCases = ({ timeout = defaultTimeout, testcaseSelector, bb 
 
   bb.setupTestSuite(
     (testcase, testcaseFunction) => {
-      if (testcaseSelector && !testcaseSelector(testcase)) return
+      if (testcaseSelector && !testcaseSelector(testcase)) return false
 
       it(
         testcase.header.name,
@@ -22,6 +22,7 @@ const setupJasmineTestCases = ({ timeout = defaultTimeout, testcaseSelector, bb 
           })
         },
         timeout)
+      return true
     },
     null,
     (err) => fail(err)

--- a/src/helpers/jest.js
+++ b/src/helpers/jest.js
@@ -7,9 +7,10 @@ const setupJestTestCases = ({ testcaseSelector, bb } = {}) => {
 
   bb.setupTestSuite(
     (testcase, testcaseFunction) => {
-      if (testcaseSelector && !testcaseSelector(testcase)) return
+      if (testcaseSelector && !testcaseSelector(testcase)) return false
 
       test(testcase.header.name, testcaseFunction)
+      return true
     }
   )
 }

--- a/src/helpers/mocha.js
+++ b/src/helpers/mocha.js
@@ -9,9 +9,10 @@ const setupMochaTestCases = ({ timeout = defaultTimeout, testcaseSelector, bb } 
 
   bb.setupTestSuite(
     (testcase, testcaseFunction) => {
-      if (testcaseSelector && !testcaseSelector(testcase)) return
+      if (testcaseSelector && !testcaseSelector(testcase)) return false
 
       it(testcase.header.name, testcaseFunction).timeout(timeout)
+      return true
     }
   )
 }


### PR DESCRIPTION
If all test cases in a test suite fails, jest will complain and fail the whole suite. This can be worked around by adding a skipped test if there's no other test.