### PR TITLE
Bump botium-core to latest (security alert remediation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/runtime": "^7.21.0",
     "async": "^3.2.4",
-    "botium-core": "1.13.16",
+    "botium-core": "1.14.9",
     "debug": "^4.3.4",
     "lodash": "^4.17.21",
     "mkdirp": "^3.0.0",


### PR DESCRIPTION
Botium-core has since lost its dependency on `vm2`, which is currently showing as a 'critical' vulnerability in npm audit (and therefore dependabot in our repository at work). This is a minimal change to deal with that alert.

I've verified that this project appears to still run successfully in the sample project:

![image](https://github.com/codeforequity-at/botium-bindings/assets/54133784/7be4c51d-68ca-4f84-afbe-466da241e378)

And `npm run build` is fine:

![image](https://github.com/codeforequity-at/botium-bindings/assets/54133784/14c10c5b-d838-453b-86c7-66b2e00a07ef)

Let me know if there's anything else I can do. There are other dependencies which could be updated, but I've kept this minimal to focus on the security issue (even though realistically most botium use cases won't be public-facing).